### PR TITLE
Process points even if there is no display client

### DIFF
--- a/web/server/index.js
+++ b/web/server/index.js
@@ -47,11 +47,15 @@ websocketServer.on('connection', (socket, req) => {
 
     // Re-broadcast latest point cloud data to client displays at a regular interval
     const intervalId = setInterval(() => {
-      if (!displaySockets[lidarId] || !pointData) {
+      if (!pointData) {
         return;
       }
 
       processPointCloud(pointData);
+
+      if (!displaySockets[lidarId]) {
+        return;
+      }
 
       for (let displaySocket of displaySockets[lidarId]) {
         try {


### PR DESCRIPTION
note: at this point it's still set to run at an interval as opposed to on every single point cloud received